### PR TITLE
Add a /redirect/number/{n} route to simulate redirect chains

### DIFF
--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class RedirectController
+{
+    /**
+     * Redirect N times, decrementing each step. The chain terminates with
+     * a 204 No Content response when the counter reaches zero.
+     *
+     * GET /redirect/number/{number}
+     */
+    public function number(Request $request, string $number): RedirectResponse|Response
+    {
+        $request->merge(['number' => $number]);
+
+        $request->validate([
+            'number' => ['required', 'integer', 'min:0', 'max:20'],
+        ]);
+
+        $count = (int) $number;
+
+        if ($count === 0) {
+            return response()->noContent();
+        }
+
+        return redirect(url('/redirect/number/'.($count - 1)), 302);
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -278,6 +278,10 @@ $ curl -X POST {{ url('/post') }} -H "Content-Type: application/json" -d '{"mess
                                 <div class="route-link"><a href="/status/418">/status/{codes}</a></div>
                                 <div class="route-description">Returns given status code or random from list</div>
                             </div>
+                            <div class="py-2">
+                                <div class="route-link"><a href="/redirect/number/3">/redirect/number/{n}</a></div>
+                                <div class="route-description">Redirects N times (302), terminating with a 204 at zero</div>
+                            </div>
                         </div>
                     </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\LatencyController;
 use App\Http\Controllers\PatchController;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\PutController;
+use App\Http\Controllers\RedirectController;
 use App\Http\Controllers\StatusController;
 use App\Http\Controllers\UserAgentController;
 use Illuminate\Support\Facades\Route;
@@ -31,6 +32,8 @@ Route::get('/gzip', GzipController::class);
 Route::get('/deny', DenyController::class);
 
 Route::any('/status/{codes}', StatusController::class);
+
+Route::get('/redirect/number/{number}', [RedirectController::class, 'number']);
 
 Route::get('/latency/random', [LatencyController::class, 'random']);
 Route::get('/latency/between/{min}/and/{max}', [LatencyController::class, 'between']);

--- a/tests/Feature/RedirectControllerTest.php
+++ b/tests/Feature/RedirectControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+it('redirects to the next number with a 302', function () {
+    $response = $this->get('/redirect/number/3');
+
+    $response->assertStatus(302);
+    $response->assertRedirect('/redirect/number/2');
+});
+
+it('terminates the chain with a 204 No Content at zero', function () {
+    $response = $this->get('/redirect/number/0');
+
+    $response->assertStatus(204);
+});
+
+it('follows the full redirect chain to completion', function () {
+    $response = $this->get('/redirect/number/3');
+
+    $response->assertStatus(302);
+    $response->assertRedirect('/redirect/number/2');
+
+    $response = $this->get('/redirect/number/2');
+    $response->assertStatus(302);
+    $response->assertRedirect('/redirect/number/1');
+
+    $response = $this->get('/redirect/number/1');
+    $response->assertStatus(302);
+    $response->assertRedirect('/redirect/number/0');
+
+    $response = $this->get('/redirect/number/0');
+    $response->assertStatus(204);
+});
+
+it('supports large redirect chains', function () {
+    $response = $this->get('/redirect/number/20');
+
+    $response->assertStatus(302);
+    $response->assertRedirect('/redirect/number/19');
+});
+
+it('returns 422 for non-integer numbers', function () {
+    $response = $this->getJson('/redirect/number/abc');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['number']);
+});
+
+it('returns 422 for negative numbers', function () {
+    $response = $this->getJson('/redirect/number/-1');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['number']);
+});
+
+it('returns 422 for numbers exceeding the maximum', function () {
+    $response = $this->getJson('/redirect/number/21');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['number']);
+});


### PR DESCRIPTION
Replaces the legacy `ohdear.app/test-routes/redirect/number/{n}` endpoint that the uptime-checker test suite still depends on, so we can drop that dependency. Each hit returns a 302 to `/redirect/number/{n-1}` and the chain terminates with a 204 at zero. Capped at 20 to keep abuse off the table.