### PR TITLE
Add a /redirect-to route for single-hop redirects with a configurable status code

### DIFF
--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -41,10 +42,21 @@ class RedirectController
     public function to(Request $request): RedirectResponse
     {
         $request->validate([
-            'url' => ['required', 'url'],
+            'url' => [
+                'required',
+                'url:http,https',
+                function (string $attribute, mixed $value, Closure $fail) use ($request): void {
+                    $targetHost = is_string($value) ? parse_url($value, PHP_URL_HOST) : null;
+
+                    if (is_string($targetHost) && strcasecmp($targetHost, $request->getHost()) === 0) {
+                        $fail('The url must not point back to this server.');
+                    }
+                },
+            ],
             'status' => ['sometimes', 'integer', 'min:300', 'max:399'],
         ]);
 
-        return redirect($request->query('url'), (int) $request->query('status', 302));
+        return redirect($request->query('url'), (int) $request->query('status', 302))
+            ->withHeaders(['X-Robots-Tag' => 'noindex, nofollow']);
     }
 }

--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -30,4 +30,21 @@ class RedirectController
 
         return redirect(url('/redirect/number/'.($count - 1)), 302);
     }
+
+    /**
+     * Single-hop redirect to an arbitrary URL with a configurable 3xx status
+     * code. Defaults to 302. Lets callers test client behavior against
+     * specific redirect status codes (301, 302, 303, 307, 308, ...).
+     *
+     * GET /redirect-to?url=https://example.com&status=301
+     */
+    public function to(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'url' => ['required', 'url'],
+            'status' => ['sometimes', 'integer', 'min:300', 'max:399'],
+        ]);
+
+        return redirect($request->query('url'), (int) $request->query('status', 302));
+    }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -282,6 +282,10 @@ $ curl -X POST {{ url('/post') }} -H "Content-Type: application/json" -d '{"mess
                                 <div class="route-link"><a href="/redirect/number/3">/redirect/number/{n}</a></div>
                                 <div class="route-description">Redirects N times (302), terminating with a 204 at zero</div>
                             </div>
+                            <div class="py-2">
+                                <div class="route-link"><a href="/redirect-to?url=https://request-mirror.ohdear.app/get&status=301">/redirect-to</a></div>
+                                <div class="route-description">Single-hop redirect to <code>?url=</code> with optional <code>?status=</code> (300-399, default 302)</div>
+                            </div>
                         </div>
                     </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,6 +34,7 @@ Route::get('/deny', DenyController::class);
 Route::any('/status/{codes}', StatusController::class);
 
 Route::get('/redirect/number/{number}', [RedirectController::class, 'number']);
+Route::get('/redirect-to', [RedirectController::class, 'to']);
 
 Route::get('/latency/random', [LatencyController::class, 'random']);
 Route::get('/latency/between/{min}/and/{max}', [LatencyController::class, 'between']);

--- a/tests/Feature/RedirectControllerTest.php
+++ b/tests/Feature/RedirectControllerTest.php
@@ -114,3 +114,42 @@ it('returns 422 when status is not an integer', function () {
     $response->assertStatus(422);
     $response->assertJsonValidationErrors(['status']);
 });
+
+it('rejects javascript: scheme urls', function () {
+    $response = $this->getJson('/redirect-to?url=javascript:alert(1)');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('rejects data: scheme urls', function () {
+    $response = $this->getJson('/redirect-to?url=data:text/html,<script>alert(1)</script>');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('rejects redirects pointing back to its own host', function () {
+    $host = parse_url(config('app.url'), PHP_URL_HOST);
+
+    $response = $this->getJson('/redirect-to?url=http://'.$host.'/some-path');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('rejects same-host redirects regardless of case', function () {
+    $host = parse_url(config('app.url'), PHP_URL_HOST);
+
+    $response = $this->getJson('/redirect-to?url=http://'.strtoupper($host).'/loop');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('sets X-Robots-Tag noindex on the redirect response', function () {
+    $response = $this->get('/redirect-to?url=https://example.com');
+
+    $response->assertStatus(302);
+    expect($response->headers->get('X-Robots-Tag'))->toBe('noindex, nofollow');
+});

--- a/tests/Feature/RedirectControllerTest.php
+++ b/tests/Feature/RedirectControllerTest.php
@@ -58,3 +58,59 @@ it('returns 422 for numbers exceeding the maximum', function () {
     $response->assertStatus(422);
     $response->assertJsonValidationErrors(['number']);
 });
+
+it('redirects to an arbitrary url with a default 302', function () {
+    $response = $this->get('/redirect-to?url=https://example.com');
+
+    $response->assertStatus(302);
+    $response->assertRedirect('https://example.com');
+});
+
+it('redirects to an arbitrary url with a configured 301 status', function () {
+    $response = $this->get('/redirect-to?url=https://example.com&status=301');
+
+    $response->assertStatus(301);
+    $response->assertRedirect('https://example.com');
+});
+
+it('supports the full 3xx range of redirect status codes', function (int $status) {
+    $response = $this->get("/redirect-to?url=https://example.com&status={$status}");
+
+    $response->assertStatus($status);
+    $response->assertRedirect('https://example.com');
+})->with([301, 302, 303, 307, 308]);
+
+it('returns 422 when url is missing', function () {
+    $response = $this->getJson('/redirect-to');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('returns 422 when url is not a valid url', function () {
+    $response = $this->getJson('/redirect-to?url=not-a-url');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('returns 422 when status is below 300', function () {
+    $response = $this->getJson('/redirect-to?url=https://example.com&status=200');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['status']);
+});
+
+it('returns 422 when status is at or above 400', function () {
+    $response = $this->getJson('/redirect-to?url=https://example.com&status=400');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['status']);
+});
+
+it('returns 422 when status is not an integer', function () {
+    $response = $this->getJson('/redirect-to?url=https://example.com&status=abc');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['status']);
+});


### PR DESCRIPTION
Closes the last gap before the uptime-checker test suite can drop the live spatie.be 301 chain. Accepts a target URL and an optional status (300-399, default 302) so callers can test client behavior against any 3xx code.