### PR TITLE
Narrow /redirect-to self-block to recursive /redirect-to targets only

### DIFF
--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -46,10 +46,18 @@ class RedirectController
                 'required',
                 'url:http,https',
                 function (string $attribute, mixed $value, Closure $fail) use ($request): void {
-                    $targetHost = is_string($value) ? parse_url($value, PHP_URL_HOST) : null;
+                    if (! is_string($value)) {
+                        return;
+                    }
 
-                    if (is_string($targetHost) && strcasecmp($targetHost, $request->getHost()) === 0) {
-                        $fail('The url must not point back to this server.');
+                    $targetHost = parse_url($value, PHP_URL_HOST);
+                    $targetPath = parse_url($value, PHP_URL_PATH);
+
+                    $sameHost = is_string($targetHost) && strcasecmp($targetHost, $request->getHost()) === 0;
+                    $loopsBack = is_string($targetPath) && rtrim($targetPath, '/') === '/redirect-to';
+
+                    if ($sameHost && $loopsBack) {
+                        $fail('The url must not loop back to /redirect-to on this server.');
                     }
                 },
             ],

--- a/tests/Feature/RedirectControllerTest.php
+++ b/tests/Feature/RedirectControllerTest.php
@@ -129,19 +129,37 @@ it('rejects data: scheme urls', function () {
     $response->assertJsonValidationErrors(['url']);
 });
 
-it('rejects redirects pointing back to its own host', function () {
+it('allows same-host redirects to other paths', function () {
     $host = parse_url(config('app.url'), PHP_URL_HOST);
 
-    $response = $this->getJson('/redirect-to?url=http://'.$host.'/some-path');
+    $response = $this->get('/redirect-to?url=http://'.$host.'/get');
+
+    $response->assertStatus(302);
+    $response->assertRedirect('http://'.$host.'/get');
+});
+
+it('rejects redirects that loop back to /redirect-to on the same host', function () {
+    $host = parse_url(config('app.url'), PHP_URL_HOST);
+
+    $response = $this->getJson('/redirect-to?url=http://'.$host.'/redirect-to?url=https://example.com');
 
     $response->assertStatus(422);
     $response->assertJsonValidationErrors(['url']);
 });
 
-it('rejects same-host redirects regardless of case', function () {
+it('rejects /redirect-to loop targets regardless of host case', function () {
     $host = parse_url(config('app.url'), PHP_URL_HOST);
 
-    $response = $this->getJson('/redirect-to?url=http://'.strtoupper($host).'/loop');
+    $response = $this->getJson('/redirect-to?url=http://'.strtoupper($host).'/redirect-to?url=https://example.com');
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['url']);
+});
+
+it('rejects /redirect-to loop targets with a trailing slash', function () {
+    $host = parse_url(config('app.url'), PHP_URL_HOST);
+
+    $response = $this->getJson('/redirect-to?url=http://'.$host.'/redirect-to/?url=https://example.com');
 
     $response->assertStatus(422);
     $response->assertJsonValidationErrors(['url']);


### PR DESCRIPTION
The previous self-host block was too aggressive: it rejected legitimate same-host targets like \`/redirect-to?url=https://request-mirror.ohdear.app/get\`, which we want for testing redirect handling against our own mirror endpoints. The actual loop attack is recursive \`/redirect-to → /redirect-to\`, not any same-host target. The check now only fires when both the host matches and the target path is \`/redirect-to\`.