### PR TITLE
Drop /redirect-to self-host validation

### DIFF
--- a/app/Http/Controllers/RedirectController.php
+++ b/app/Http/Controllers/RedirectController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -42,17 +41,7 @@ class RedirectController
     public function to(Request $request): RedirectResponse
     {
         $request->validate([
-            'url' => [
-                'required',
-                'url:http,https',
-                function (string $attribute, mixed $value, Closure $fail) use ($request): void {
-                    $targetHost = is_string($value) ? parse_url($value, PHP_URL_HOST) : null;
-
-                    if (is_string($targetHost) && strcasecmp($targetHost, $request->getHost()) === 0) {
-                        $fail('The url must not point back to this server.');
-                    }
-                },
-            ],
+            'url' => ['required', 'url:http,https'],
             'status' => ['sometimes', 'integer', 'min:300', 'max:399'],
         ]);
 

--- a/tests/Feature/RedirectControllerTest.php
+++ b/tests/Feature/RedirectControllerTest.php
@@ -129,24 +129,6 @@ it('rejects data: scheme urls', function () {
     $response->assertJsonValidationErrors(['url']);
 });
 
-it('rejects redirects pointing back to its own host', function () {
-    $host = parse_url(config('app.url'), PHP_URL_HOST);
-
-    $response = $this->getJson('/redirect-to?url=http://'.$host.'/some-path');
-
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['url']);
-});
-
-it('rejects same-host redirects regardless of case', function () {
-    $host = parse_url(config('app.url'), PHP_URL_HOST);
-
-    $response = $this->getJson('/redirect-to?url=http://'.strtoupper($host).'/loop');
-
-    $response->assertStatus(422);
-    $response->assertJsonValidationErrors(['url']);
-});
-
 it('sets X-Robots-Tag noindex on the redirect response', function () {
     $response = $this->get('/redirect-to?url=https://example.com');
 


### PR DESCRIPTION
The self-host check was cargo-cult. A recursive \`/redirect-to → /redirect-to\` chain is bounded by every HTTP client's max_redirects setting (Guzzle 5, curl 50, browsers ~20), so the rule prevented no real abuse — just made the endpoint less useful for testing same-host redirect behavior. Scheme allowlist (http/https) and the \`X-Robots-Tag: noindex, nofollow\` response header stay; those carry their weight.